### PR TITLE
Potential fix for code scanning alert no. 17: Flask app is run in debug mode

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,3 +5,4 @@ MYSQL_DB=""
 
 #BASE_URL="/"
 #STATIC_URL_PREFIX=""
+#FLASK_DEBUG=False

--- a/gui.py
+++ b/gui.py
@@ -548,4 +548,5 @@ def logout():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 'yes']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/17](https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/17)

To fix the issue, we should ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable to control the debug mode. Specifically:
1. Introduce a new environment variable, such as `FLASK_DEBUG`, to determine whether the app should run in debug mode.
2. Modify the `app.run()` call to set `debug` based on the value of this environment variable. If the variable is not set, default to `False` (production-safe).
3. Update the `if __name__ == '__main__':` block to include this logic.

This approach ensures that debug mode is only enabled when explicitly configured, reducing the risk of accidental exposure in production.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
