### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/1](https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/1)

To fix the issue, we need to explicitly define the `permissions` block in the workflow file. Since the workflow only requires read access to the repository contents (to check out the code and run `pylint`), we will set `contents: read` at the workflow level. This ensures that the `GITHUB_TOKEN` has the minimal permissions required to execute the workflow safely.

The `permissions` block will be added at the root level of the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
