### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-and-restart-api.yml
+++ b/.github/workflows/deploy-and-restart-api.yml
@@ -3,6 +3,9 @@ name: Deploy on github actions runner
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: self-hosted


### PR DESCRIPTION
Potential fix for [https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/31](https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/31)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow interacts with the repository to pull the latest changes (`git pull origin main`), it requires `contents: read` permissions. No other permissions are necessary based on the provided workflow steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
