### PR TITLE
UID kann jetzt auch ATS sein, daher allgemeiner formulieren

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -13,6 +13,8 @@
 name: Bandit
 on:
   workflow_call:
+  pull_request:
+    branches: [ "main" ]
   schedule:
     - cron: '33 23 * * 6'
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,7 +3,6 @@ name: Pylint
 on:
   workflow_call:
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "main" ]
 
 permissions:

--- a/api.py
+++ b/api.py
@@ -71,38 +71,39 @@ def api_key_required(f):
     return decorated
 
 
-def finde_benutzer_zu_nfc_uid(uid_base64):
+def finde_benutzer_zu_nfc_token(token_base64):
     """
-    Findet einen Benutzer in der Datenbank anhand der Base64-kodierten NFC-UID.
+    Findet einen Benutzer in der Datenbank anhand der Base64-kodierten Daten eines NFC-Tokens.
 
     Args:
-        uid_base64 (str): Die Base64-kodierte NFC-UID des Tokens.
+        token_base64 (str): Die Base64-kodierte NFC-Daten des Tokens.
 
     Returns:
         int or None: Die ID des Benutzers oder None, falls kein Benutzer gefunden wird.
+        str or None: Der Nachname des Benutzers oder None, falls kein Benutzer gefunden wird.
+        str or None: Der Vorname des Benutzer oder None, falls kein Benutzer gefunden wird.
     """
 
     cnx = db_utils.DatabaseConnectionPool.get_connection(config.db_config)
     if not cnx:
-        return None, None
+        return None, None, None
     cursor = cnx.cursor()
 
     try:
-        uid_bytes = base64.b64decode(uid_base64)
+        token_bytes = base64.b64decode(token_base64)
 
-        #cursor.execute("SELECT id, nachname, vorname FROM users WHERE nfc_uid = %s", (uid_bytes,))
-        cursor.execute("SELECT u.id AS id, u.nachname AS nachname, u.vorname AS vorname FROM nfc_token AS t INNER JOIN users AS u ON t.user_id = u.id WHERE t.token_uid = %s", (uid_bytes,))
+        cursor.execute("SELECT u.id AS id, u.nachname AS nachname, u.vorname AS vorname FROM nfc_token AS t INNER JOIN users AS u ON t.user_id = u.id WHERE t.token_daten = %s", (token_bytes,))
         user = cursor.fetchone()
         if user:
             print(f"Benutzer gefunden: {user[0]} - {user[1]}, {user[2]}") # ID, Nachnachme, Vorname
             return user[0], user[1], user[2]
-        return None
+        return None, None, None
     except Error as err:
-        print(f"Fehler beim Suchen des Benutzers anhand der UID: {err}")
-        return None
+        print(f"Fehler beim Suchen des Benutzers anhand des Tokens: {err}")
+        return None, None, None
     except base64.binascii.Error:
-        print(f"Fehler: Ungültiger Base64-String: {uid_base64}")
-        return None
+        print(f"Fehler: Ungültiger Base64-String: {token_base64}")
+        return None, None, None
     finally:
         cursor.close()
         db_utils.DatabaseConnectionPool.close_connection(cnx)
@@ -169,61 +170,12 @@ def get_alle_summe(user_id, username):
         db_utils.DatabaseConnectionPool.close_connection(cnx)
 
 
-# @app.route('/nfc-saldoabfrage', methods=['POST'])
-# @api_key_required
-# def nfc_saldoabfrage(user_id, username):
-#     """
-#     Holt den aktuelle Saldo des Token-Besitzer aus der Datenbank.
-
-#     Args:
-#         user_id (int): Die ID des authentifizierten API-Benutzers.
-#         username (str): Der Benutzername des authentifizierten API-Benutzers.
-
-#     Returns:
-#         flask.Response: Eine JSON-Antwort mit dem Saldo oder einem Fehler.
-#     """
-
-#     print(f"Benutzer authentifiziert {user_id} - {username}.")
-#     daten = request.get_json()
-#     if not daten or 'uid' not in daten:
-#         return jsonify({'error': 'Ungültige Anfrage. Die UID des NFC-Tokens fehlt.'}), 400
-
-#     nfc_uid = daten['uid']
-#     benutzer_id, benutzer_nachname, benutzer_vorname = finde_benutzer_zu_nfc_uid(nfc_uid)
-
-#     if benutzer_id:
-#         cnx = db_utils.DatabaseConnectionPool.get_connection(config.db_config)
-#         if not cnx:
-#             return jsonify({'error': 'Datenbankverbindung fehlgeschlagen.'}), 500
-#         cursor = cnx.cursor(dictionary=True)
-#         try:
-#             cursor.execute(
-#                 "SELECT u.nachname AS nachname, u.vorname AS vorname, SUM(t.saldo_aenderung) AS saldo " \
-#                 "FROM transactions AS t INNER JOIN users AS u ON t.user_id = u.id WHERE u.id = %s GROUP BY u.nachname, u.vorname", (benutzer_id,))
-#             person = cursor.fetchone()
-
-#             if person:
-#                 print(f"Person mit Code {benutzer_id} gefunden: {person['nachname']}, {person['vorname']} - Saldo {person['saldo']}")
-#                 return jsonify(person)
-#             print(f"Person mit Code {benutzer_id} hat noch keine Transaktionen durchgeführt.")
-#             return jsonify({'error': 'Person hat noch keine Transaktionen durchgeführt.'}), 200
-
-#         except Error as err:
-#             print(f"Fehler beim Lesen der Daten: {err}")
-#             return jsonify({'error': 'Fehler beim Lesen der Daten.'}), 500
-#         finally:
-#             cursor.close()
-#             db_utils.DatabaseConnectionPool.close_connection(cnx)
-#     else:
-#         return jsonify({'error': f'Kein Benutzer mit der UID {nfc_uid} gefunden.'}), 404
-
-
 @app.route('/nfc-transaktion', methods=['PUT'])
 @api_key_required
 def nfc_transaction(user_id, username):
     """
-    Verarbeitet eine NFC-Transaktion, indem die übermittelte UID einem Benutzer zugeordnet
-    und 1 Strich in der Datenbank vermerkt wird.
+    Verarbeitet eine NFC-Transaktion, indem die übermittelten Tokendaten (ATS oder UID) einem Benutzer zugeordnet
+    und -1 Saldo  in der Datenbank vermerkt wird.
 
     Args:
         user_id (int): Die ID des authentifizierten API-Benutzers.
@@ -235,17 +187,22 @@ def nfc_transaction(user_id, username):
 
     print(f"Benutzer authentifiziert {user_id} - {username}.")
     daten = request.get_json()
-    if not daten or 'uid' not in daten:
-        return jsonify({'error': 'Ungültige Anfrage. Die UID des NFC-Tokens fehlt.'}), 400
+    if not daten or 'token' not in daten:
+        return jsonify({'error': 'Ungültige Anfrage. Die Daten des NFC-Tokens fehlen.'}), 400
 
-    nfc_uid = daten['uid']
-    benutzer_id, benutzer_nachname, benutzer_vorname = finde_benutzer_zu_nfc_uid(nfc_uid)
+    nfc_token = daten['token']
+
+    benutzer_id, benutzer_nachname, benutzer_vorname = finde_benutzer_zu_nfc_token(nfc_token)
 
     if benutzer_id:
         cnx = db_utils.DatabaseConnectionPool.get_connection(config.db_config)
         if not cnx:
             return jsonify({'error': 'Datenbankverbindung fehlgeschlagen.'}), 500
         cursor = cnx.cursor(dictionary=True)
+
+        # TODO
+        # hier muss noch der last_used Eintrag des NFC-Tokens aktualisiert werden!
+
         try:
             artikel = "NFC-Scan"
             saldo_aenderung = -1
@@ -272,7 +229,7 @@ def nfc_transaction(user_id, username):
             cursor.close()
             db_utils.DatabaseConnectionPool.close_connection(cnx)
     else:
-        return jsonify({'error': f'Kein Benutzer mit der UID {nfc_uid} gefunden.'}), 404
+        return jsonify({'error': f'Kein Benutzer mit dem Token {nfc_token} gefunden.'}), 404
 
 
 @app.route('/transaktionen', methods=['GET'])

--- a/api.py
+++ b/api.py
@@ -93,7 +93,8 @@ def finde_benutzer_zu_nfc_token(token_base64):
     try:
         token_bytes = base64.b64decode(token_base64)
 
-        cursor.execute("SELECT u.id AS id, u.nachname AS nachname, u.vorname AS vorname, t.token_id as token_id FROM nfc_token AS t INNER JOIN users AS u ON t.user_id = u.id WHERE t.token_daten = %s", (token_bytes,))
+        cursor.execute("SELECT u.id AS id, u.nachname AS nachname, u.vorname AS vorname, t.token_id as token_id " \
+        "FROM nfc_token AS t INNER JOIN users AS u ON t.user_id = u.id WHERE t.token_daten = %s", (token_bytes,))
         user = cursor.fetchone()
         if user:
             print(f"Benutzer: {user[0]} - {user[1]}, {user[2]} (TokenID: {user[3]})") # ID, Nachnachme, Vorname, TokenID
@@ -203,7 +204,6 @@ def nfc_transaction(user_id, username):
 
         try:
             sql_transaktion = "UPDATE nfc_token SET last_used = NOW() WHERE token_id = %s"
-            #print(f"aktualisiere last_used: {sql_transaktion} - {benutzer_token_id} ")
             cursor.execute(sql_transaktion, (benutzer_token_id,))
             cnx.commit()
         except Error as err:
@@ -226,7 +226,6 @@ def nfc_transaction(user_id, username):
             person = cursor.fetchone()
             if person:
                 print(f"Benutzer ID {benutzer_id} gefunden: {benutzer_vorname} {benutzer_nachname} - Aktueller Saldo: {person['saldo']}")
-                #return jsonify({'message': f'Danke {benutzer_vorname} {benutzer_nachname}. Dein aktueller Saldo beträgt: {person["saldo"]}.'}), 200
                 return jsonify({'message': f'Danke {benutzer_vorname}. Dein aktueller Saldo beträgt: {person["saldo"]}.'}), 200
             return jsonify({'message': f'Transaktion für {benutzer_vorname} {benutzer_nachname} erfolgreich erstellt (Saldo {saldo_aenderung}).'}), 200 # dieser Code sollte nie erreicht werden
         except Error as err:

--- a/gui.py
+++ b/gui.py
@@ -3,7 +3,6 @@
 import binascii
 import os
 import sys
-from datetime import datetime
 from dotenv import load_dotenv
 from flask import Flask, render_template, request, redirect, url_for, session, flash # pigar: required-packages=uWSGI
 from werkzeug.security import check_password_hash, generate_password_hash

--- a/gui.py
+++ b/gui.py
@@ -3,6 +3,7 @@
 import binascii
 import os
 import sys
+from datetime import datetime
 from dotenv import load_dotenv
 from flask import Flask, render_template, request, redirect, url_for, session, flash # pigar: required-packages=uWSGI
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -361,7 +362,7 @@ def get_user_nfc_tokens(user_id):
     if cnx:
         cursor = cnx.cursor(dictionary=True)
         try:
-            query = "SELECT token_id, token_name, token_daten, last_used FROM nfc_token WHERE user_id = %s ORDER BY last_used DESC"
+            query = "SELECT token_id, token_name, token_daten, last_used, DATEDIFF(CURDATE(), DATE(last_used)) AS last_used_days_ago FROM nfc_token WHERE user_id = %s ORDER BY last_used DESC"
             cursor.execute(query, (user_id,))
             transactions = cursor.fetchall()
             return transactions

--- a/gui.py
+++ b/gui.py
@@ -38,7 +38,7 @@ def hex_to_binary(hex_string):
     Konvertiert einen Hexadezimalstring in Binärdaten.
 
     Diese Funktion nimmt einen Hexadezimalstring entgegen und wandelt ihn in die entsprechende
-    Binärdarstellung um.  Sie wird typischerweise verwendet, um NFC-UIDs zu verarbeiten,
+    Binärdarstellung um.  Sie wird typischerweise verwendet, um NFC-Token Daten zu verarbeiten,
     die oft als Hexadezimalstrings dargestellt werden.
 
     Args:
@@ -59,26 +59,26 @@ def hex_to_binary(hex_string):
         return None
 
 
-def add_user_nfc_token(user_id, token_name, hex_uid):
+def add_user_nfc_token(user_id, token_name, token_hex):
     """
     Fügt einen neuen NFC-Token der Datenbank hinzu.
 
     Args:
         user_id (int): Die ID des Benutzers.
-        hex_uid (str): Die Hexadezimaldarstellung der NFC-UID.
+        token_hex (str): Die Hexadezimaldarstellung der NFC-Token Daten.
 
     Returns:
-        bool: True bei Erfolg, False bei Fehler (z.B. ungültige UID, Datenbankfehler).
+        bool: True bei Erfolg, False bei Fehler (z.B. ungültige Daten, Datenbankfehler).
     """
 
     cnx = db_utils.DatabaseConnectionPool.get_connection(config.db_config)
     if cnx:
         cursor = cnx.cursor()
-        binary_uid = hex_to_binary(hex_uid)
-        if binary_uid:
+        token_binary = hex_to_binary(token_hex)
+        if token_binary:
             try:
-                query = "INSERT INTO nfc_token SET user_id = %s, token_name = %s, token_uid = %s, last_used = NOW()"
-                cursor.execute(query, (user_id, token_name, binary_uid))
+                query = "INSERT INTO nfc_token SET user_id = %s, token_name = %s, token_daten = %s, last_used = NOW()"
+                cursor.execute(query, (user_id, token_name, token_binary))
                 cnx.commit()
                 return True
             except Error as err:
@@ -89,7 +89,7 @@ def add_user_nfc_token(user_id, token_name, hex_uid):
                 cursor.close()
                 db_utils.DatabaseConnectionPool.close_connection(cnx)
         else:
-            flash('Ungültige NFC-UID. Bitte überprüfe die Eingabe.', 'error')
+            flash('Ungültige NFC-Token Daten. Bitte überprüfe die Eingabe.', 'error')
             return False
     return False
 
@@ -124,7 +124,7 @@ def delete_user_nfc_token(user_id, token_id):
                 cursor.close()
                 db_utils.DatabaseConnectionPool.close_connection(cnx)
         else:
-            flash('Ungültige NFC-UID. Bitte überprüfe die Eingabe.', 'error')
+            flash('Ungültige NFC-Token Daten. Bitte überprüfe die Eingabe.', 'error')
             return False
     return False
 
@@ -222,7 +222,7 @@ def fetch_user(code):
 
 def get_user_by_id(user_id):
     """
-    Ruft einen Benutzer anhand seiner ID ab und holt die zugehörige NFC-UID.
+    Ruft einen Benutzer anhand seiner ID ab und holt die zugehörige NFC-Token Daten.
 
     Args:
         user_id (int): Die ID des Benutzers.
@@ -317,7 +317,7 @@ def get_saldo_by_user():
 
 def get_all_users():
     """
-    Ruft alle Benutzer aus der Datenbank ab, sortiert nach Namen, und holt die zugehörige NFC-UID.
+    Ruft alle Benutzer aus der Datenbank ab, sortiert nach Namen, und holt die zugehörige NFC-Token Daten.
 
     Returns:
         list: Eine Liste von Dictionaries, wobei jedes Dictionary einen Benutzer repräsentiert
@@ -354,14 +354,14 @@ def get_user_nfc_tokens(user_id):
 
     Returns:
         list: Eine Liste von Dictionaries, wobei jedes Dictionary einen Token repräsentiert
-              (token_id, token_name, token_uid, last_used). Gibt None zurück, falls ein Fehler auftritt.
+              (token_id, token_name, token_daten, last_used). Gibt None zurück, falls ein Fehler auftritt.
     """
 
     cnx = db_utils.DatabaseConnectionPool.get_connection(config.db_config)
     if cnx:
         cursor = cnx.cursor(dictionary=True)
         try:
-            query = "SELECT token_id, token_name, token_uid, last_used FROM nfc_token WHERE user_id = %s ORDER BY last_used DESC"
+            query = "SELECT token_id, token_name, token_daten, last_used FROM nfc_token WHERE user_id = %s ORDER BY last_used DESC"
             cursor.execute(query, (user_id,))
             transactions = cursor.fetchall()
             return transactions
@@ -650,8 +650,8 @@ def admin_user_modification(user_id):
             flash(f'Fehler beim Löschen des Benutzers "{target_user["nachname"]}, {target_user["vorname"]}" (ID {user_id}).', 'error')
         elif 'add_user_nfc_token' in request.form:
             nfc_token_name = request.form['nfc_token_name']
-            nfc_token_uid = request.form['nfc_token_uid']
-            if add_user_nfc_token(user_id, nfc_token_name, nfc_token_uid):
+            nfc_token_daten = request.form['nfc_token_daten']
+            if add_user_nfc_token(user_id, nfc_token_name, nfc_token_daten):
                 flash('NFC-Token erfolgreich hinzugefügt.', 'success')
                 return redirect(BASE_URL + url_for('admin_user_modification', user_id=user_id))
             flash('Fehler beim Hinzufügen des NFC-Tokens.', 'error')

--- a/templates/admin_user_modification.html
+++ b/templates/admin_user_modification.html
@@ -76,7 +76,13 @@
                 <td>{{ nfc_token.token_id }}</td>
                 <td>{{ nfc_token.token_name }}</td>
                 <td>{{ nfc_token.token_daten.hex() }}</td>
-                <td>{{ nfc_token.last_used }}</td>
+                <td>{{ nfc_token.last_used }}
+                    {% if nfc_token.last_used_days_ago == 0 %}
+                    (heute)
+                    {% else %}
+                    (vor {{ nfc_token.last_used_days_ago }} Tagen)
+                    {% endif %}
+                </td>
                 <td>
                     <form method="POST" class="compact-delete-form" onsubmit="return confirm('Möchtest du diesen Token wirklich löschen?');">
                         <input type="hidden" name="nfc_token_id" value="{{ nfc_token.token_id}}">

--- a/templates/admin_user_modification.html
+++ b/templates/admin_user_modification.html
@@ -65,7 +65,7 @@
             <tr>
                 <th>ID</th>
                 <th>Name</th>
-                <th>UID</th>
+                <th>Daten</th>
                 <th>zuletzt verwendet</th>
                 <th>Aktion</th>
             </tr>
@@ -75,7 +75,7 @@
             <tr>
                 <td>{{ nfc_token.token_id }}</td>
                 <td>{{ nfc_token.token_name }}</td>
-                <td>{{ nfc_token.token_uid.hex() }}</td>
+                <td>{{ nfc_token.token_daten.hex() }}</td>
                 <td>{{ nfc_token.last_used }}</td>
                 <td>
                     <form method="POST" class="compact-delete-form" onsubmit="return confirm('Möchtest du diesen Token wirklich löschen?');">
@@ -96,8 +96,8 @@
     <form method="POST" class="inline-form-transaction">
         <label for="nfc_token_name">NFC-Name:</label>
         <input type="text" id="nfc_token_name" name="nfc_token_name" title="Bitte gib deinem Token einen Namen.">
-        <label for="nfc_token_uid">NFC-UID (hexadezimal):</label>
-        <input type="text" id="nfc_token_uid" name="nfc_token_uid" required pattern="[0-9A-Fa-f]{2,}" title="Bitte gib eine Hexadezimalzahl mit mindestens 2 Zeichen ein.">
+        <label for="nfc_token_daten">NFC-Daten (hexadezimal):</label>
+        <input type="text" id="nfc_token_daten" name="nfc_token_daten" required pattern="[0-9A-Fa-f]{2,}" title="Bitte gib eine Hexadezimalzahl mit mindestens 2 Zeichen ein.">
         <button type="submit" name="add_user_nfc_token">Hinzufügen</button>
     </form>
 

--- a/templates/user_info.html
+++ b/templates/user_info.html
@@ -56,7 +56,7 @@
         <thead>
             <tr>
                 <th>Name</th>
-                <th>UID</th>
+                <th>Daten</th>
                 <th>zuletzt verwendet</th>
             </tr>
         </thead>
@@ -64,7 +64,7 @@
             {% for nfc_token in nfc_tokens %}
             <tr>
                 <td>{{ nfc_token.token_name }}</td>
-                <td>{{ nfc_token.token_uid.hex() }}</td>
+                <td>{{ nfc_token.token_daten.hex() }}</td>
                 <td>{{ nfc_token.last_used }}</td>
             </tr>
             {% endfor %}

--- a/templates/user_info.html
+++ b/templates/user_info.html
@@ -65,7 +65,13 @@
             <tr>
                 <td>{{ nfc_token.token_name }}</td>
                 <td>{{ nfc_token.token_daten.hex() }}</td>
-                <td>{{ nfc_token.last_used }}</td>
+                <td>{{ nfc_token.last_used }}
+                    {% if nfc_token.last_used_days_ago == 0 %}
+                    (heute)
+                    {% else %}
+                    (vor {{ nfc_token.last_used_days_ago }} Tagen)
+                    {% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
Handys liefern eine Random-UID, daher kann diese nicht zur Identifikation eines Geräts verwendet werden.

normale NFC Hardware Token liefern keine ATS Daten.

Lösung: zuerst schauen, ob ATS Daten gelesen werden können. Falls ja werden diese als Token-ID verwendet (diese verändern sich nicht in bisherigen Tests). Falls keine ATS Daten gelesen werden können wird die UID des Tokens als ID gespeichert.