### PR TITLE
Potential fix for code scanning alert no. 48: Information exposure through an exception

### DIFF
--- a/api.py
+++ b/api.py
@@ -564,7 +564,7 @@ def get_all_users(api_user_id: int, api_username: str):
         return jsonify(users_list), 200
     except Error as err:
         logger.error("Fehler beim Abrufen aller Benutzer aus der Datenbank: %s", err)
-        return jsonify({'error': f"Fehler beim Abrufen der Benutzerdaten: {err}"}), 500
+        return jsonify({'error': "Ein interner Fehler ist aufgetreten."}), 500
     finally:
         if cnx:
             db_utils.DatabaseConnectionPool.close_connection(cnx)


### PR DESCRIPTION
Potential fix for [https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/48](https://github.com/magenbrot/Feuerwehr-Versorgungs-Helfer-API/security/code-scanning/48)

To fix the issue, the error message returned to the user should be generic and should not include sensitive details from the exception. The detailed error information should be logged internally using the existing `logger.error` mechanism. This ensures that developers can still debug issues while preventing sensitive information from being exposed to external users.

The fix involves:
1. Replacing the exposed error message with a generic message, such as `"Ein interner Fehler ist aufgetreten."`.
2. Logging the detailed error message (`err`) internally using `logger.error`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
